### PR TITLE
Add intellij related objects to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ hs_err_pid*
 
 .idea
 data
+target/
+SparrowRecSys.iml


### PR DESCRIPTION
Open the project with IntelliJ will create SparrowRecSys.iml by default, better to ignore.

Also, target/ is generated after running the RecSysServer, better to ignore.