### PR TITLE
DeepFM add first-order term in FM layer

### DIFF
--- a/TFRecModel/src/com/wzhe/sparrowrecsys/offline/tensorflow/DeepFM.py
+++ b/TFRecModel/src/com/wzhe/sparrowrecsys/offline/tensorflow/DeepFM.py
@@ -52,10 +52,12 @@ inputs = {
 # movie id embedding feature
 movie_col = tf.feature_column.categorical_column_with_identity(key='movieId', num_buckets=1001)
 movie_emb_col = tf.feature_column.embedding_column(movie_col, 10)
+movie_ind_col = tf.feature_column.indicator_column(movie_col) # movid id indicator columns
 
 # user id embedding feature
 user_col = tf.feature_column.categorical_column_with_identity(key='userId', num_buckets=30001)
 user_emb_col = tf.feature_column.embedding_column(user_col, 10)
+user_ind_col = tf.feature_column.indicator_column(user_col) # user id indicator columns
 
 # genre features vocabulary
 genre_vocab = ['Film-Noir', 'Action', 'Adventure', 'Horror', 'Romance', 'War', 'Comedy', 'Western', 'Documentary',
@@ -65,10 +67,15 @@ genre_vocab = ['Film-Noir', 'Action', 'Adventure', 'Horror', 'Romance', 'War', '
 user_genre_col = tf.feature_column.categorical_column_with_vocabulary_list(key="userGenre1",
                                                                            vocabulary_list=genre_vocab)
 user_genre_emb_col = tf.feature_column.embedding_column(user_genre_col, 10)
+user_genre_ind_col = tf.feature_column.indicator_column(user_genre_col) # user genre indicator columns
 # item genre embedding feature
 item_genre_col = tf.feature_column.categorical_column_with_vocabulary_list(key="movieGenre1",
                                                                            vocabulary_list=genre_vocab)
 item_genre_emb_col = tf.feature_column.embedding_column(item_genre_col, 10)
+item_genre_ind_col = tf.feature_column.indicator_column(item_genre_col) # item genre indicator columns
+
+# fm first-order term columns: without embedding and concatenate to the output layer directly
+fm_first_order_columns = [movie_ind_col, user_ind_col, user_genre_ind_col, item_genre_ind_col]
 
 deep_feature_columns = [tf.feature_column.numeric_column('releaseYear'),
                         tf.feature_column.numeric_column('movieRatingCount'),
@@ -85,6 +92,9 @@ user_emb_layer = tf.keras.layers.DenseFeatures([user_emb_col])(inputs)
 item_genre_emb_layer = tf.keras.layers.DenseFeatures([item_genre_emb_col])(inputs)
 user_genre_emb_layer = tf.keras.layers.DenseFeatures([user_genre_emb_col])(inputs)
 
+# The first-order term in the FM layer
+fm_first_order_layer = tf.keras.layers.DenseFeatures(fm_first_order_columns)(inputs)
+
 # FM part, cross different categorical feature embeddings
 product_layer_item_user = tf.keras.layers.Dot(axes=1)([item_emb_layer, user_emb_layer])
 product_layer_item_genre_user_genre = tf.keras.layers.Dot(axes=1)([item_genre_emb_layer, user_genre_emb_layer])
@@ -97,7 +107,7 @@ deep = tf.keras.layers.Dense(64, activation='relu')(deep)
 deep = tf.keras.layers.Dense(64, activation='relu')(deep)
 
 # concatenate fm part and deep part
-concat_layer = tf.keras.layers.concatenate([product_layer_item_user, product_layer_item_genre_user_genre,
+concat_layer = tf.keras.layers.concatenate([fm_first_order_layer, product_layer_item_user, product_layer_item_genre_user_genre,
                                             product_layer_item_genre_user, product_layer_user_genre_item, deep], axis=1)
 output_layer = tf.keras.layers.Dense(1, activation='sigmoid')(concat_layer)
 


### PR DESCRIPTION
I add the moive_id, user_id, user_genre, and item genre as the first-order term in the FM layer to perfect the DeepFM model. 

More specifically, I use these one-hot categorical features directly concatenate to the output layer without embedding.

By the way, the test accuracy was rising to 0.7593 from 0.7576 by this operation.

If have any questions or something not good, please tell me! Thanks!