### PR TITLE
fix bug by " 'tensorflow_core.keras' has no attribute 'sum' "

### DIFF
--- a/TFRecModel/src/com/sparrowrecsys/offline/tensorflow/DIN.py
+++ b/TFRecModel/src/com/sparrowrecsys/offline/tensorflow/DIN.py
@@ -134,7 +134,7 @@ activation_unit = tf.keras.layers.Permute((2, 1))(activation_unit)
 activation_unit = tf.keras.layers.Multiply()([user_behaviors_emb_layer, activation_unit])
 
 # sum pooling
-user_behaviors_pooled_layers = tf.keras.layers.Lambda(lambda x: tf.keras.sum(x, axis=1))(activation_unit)
+user_behaviors_pooled_layers = tf.keras.layers.Lambda(lambda x: tf.keras.backend.sum(x, axis=1))(activation_unit)
 
 # fc layer
 concat_layer = tf.keras.layers.concatenate([user_profile_layer, user_behaviors_pooled_layers,


### PR DESCRIPTION
The following bugs occur when running the DIN model (TensorFlow2.3 Recommended according to geekbang course)
<img width="1395" alt="Screen Shot 2021-01-10 at 15 50 25" src="https://user-images.githubusercontent.com/24987501/104117520-dc1e4500-535c-11eb-89aa-54da19439557.png">

The reason for the error is that the attribute 'sum' is not in 'tf.keras' but in 'tf.keras.backend'.