### PR TITLE
Fix bug in oneRandomWalk

### DIFF
--- a/src/main/java/com/sparrowrecsys/offline/spark/embedding/Embedding.scala
+++ b/src/main/java/com/sparrowrecsys/offline/spark/embedding/Embedding.scala
@@ -162,8 +162,10 @@ object Embedding {
 
       val probDistribution = transitionMatrix(curElement)
       val randomDouble = Random.nextDouble()
+      var accumulateProb: Double = 0D
       breakable { for ((item, prob) <- probDistribution) {
-        if (randomDouble >= prob){
+        accumulateProb += prob
+        if (accumulateProb >= randomDouble){
           curElement = item
           break
         }


### PR DESCRIPTION
The original code for choosing next item in random walk seems not correct. Fixed it using the same way to generate first item.