### PR TITLE
fix: correct movie similarity calculation in calculateSimilarScore

### DIFF
--- a/src/main/java/com/sparrowrecsys/online/recprocess/SimilarMovieProcess.java
+++ b/src/main/java/com/sparrowrecsys/online/recprocess/SimilarMovieProcess.java
@@ -149,7 +149,7 @@ public class SimilarMovieProcess {
                 sameGenreCount++;
             }
         }
-        double genreSimilarity = (double)sameGenreCount / (movie.getGenres().size() + candidate.getGenres().size()) / 2;
+        double genreSimilarity = (double)sameGenreCount / ((movie.getGenres().size() + candidate.getGenres().size()) / 2.0);
         double ratingScore = candidate.getAverageRating() / 5;
 
         double similarityWeight = 0.7;


### PR DESCRIPTION
public static double calculateSimilarScore(Movie movie, Movie candidate){
        int sameGenreCount = 0;
        for (String genre : movie.getGenres()){
            if (candidate.getGenres().contains(genre)){
                sameGenreCount++;
            }
        }
        double genreSimilarity = (double)sameGenreCount / (movie.getGenres().size() + candidate.getGenres().size()) / 2;
        
        double ratingScore = candidate.getAverageRating() / 5;

        double similarityWeight = 0.7;
        double ratingScoreWeight = 0.3;

        return genreSimilarity * similarityWeight + ratingScore * ratingScoreWeight;
    }

王喆老师你好，我说一下我对这段代码的理解哈：我觉得你可能是想把 genreSimilarity  和 ratingScore 的值都弄到 [0,1] 的范围，相当于DL中的归一化了，然后各自乘以设定好的权重。

如果我的理解没错的话，那最后就不应该是除以2了，而是乘以2才对，我改成了在分母除以 2.0

不知道我理解得对不对，如果错了的话，就请直接关闭这个PR吧